### PR TITLE
feature: Add pattern for relative imports override

### DIFF
--- a/src/rules/import-alias.ts
+++ b/src/rules/import-alias.ts
@@ -51,17 +51,14 @@ function isPermittedRelativeImport(
         }
 
         if (isGlobImport(relativeImportOverride)) {
-            console.log("here", pathSep);
-
-            const filename = filepath.split("/").at(-1) ?? "";
             const { pattern, depth } = relativeImportOverride;
 
-            if (pattern instanceof RegExp && pattern.test(filename)) {
+            if (pattern instanceof RegExp && pattern.test(filepath)) {
                 return depth >= relativeDepth;
             }
 
+            const filename = filepath.split("/").at(-1) ?? "";
             if (typeof pattern === "string" && filename === pattern) {
-                console.log("b", depth, relativeDepth, depth >= relativeDepth);
                 return depth >= relativeDepth;
             }
         }

--- a/src/rules/import-alias.ts
+++ b/src/rules/import-alias.ts
@@ -33,6 +33,8 @@ function isPermittedRelativeImport(
     relativeImportOverrides.filter((config) => {
         if (config.pattern) {
             const regex = new RegExp(config.pattern);
+            console.log("regex", regex, filepath);
+            console.log("regex2", regex.test(filepath));
             if (regex.test && regex.test(filepath)) {
                 patternsMatchs.push({
                     type: "pattern",
@@ -167,13 +169,41 @@ interface RelativePathConfig {
      *      3. `import "../bar"` when `depth` \>= `1`.
      */
     depth: number;
+    /**
+     * utility type
+     */
     pattern: never;
 }
 
 interface RelativeGlobConfig {
-    // TODO: add description;
+    /**
+     * A regex string pattern that is used to match the file path.
+     *
+     * @example
+     * With a configuration like `{ path: "index.ts", depth: 0 }`
+     *      1. Relative paths can be used in "**\/index.ts" and all file that matches the pattern.
+     *      2. Relative paths can NOT be used in `./src`.
+     *
+     * @example
+     * With a configuration like `{ path: "index{3,4}$", depth: 0 }`
+     *      1. Relative paths can be used in any file that ends with `index...` or `index....`.
+     *      2. Relative paths can be used in `./src`.
+     */
     pattern: string;
+    /**
+     * A positive number which represents the relative depth
+     * that is acceptable for the associated path.
+     *
+     * @example
+     * In `./src/foo` with `path: "src"`
+     *      1. `import "./bar"` for `./src/bar` when `depth` \>= `0`.
+     *      2. `import "./bar/baz"` when `depth` \>= `0`.
+     *      3. `import "../bar"` when `depth` \>= `1`.
+     */
     depth: number;
+    /**
+     * utility type
+     */
     path: never;
 }
 type RelativeImportConfig = RelativePathConfig | RelativeGlobConfig;

--- a/tests/rules/import-alias.test.ts
+++ b/tests/rules/import-alias.test.ts
@@ -39,23 +39,6 @@ function runTests(platform: "win32" | "posix") {
             sep: path[platform].sep,
             join: path[platform].join,
         });
-
-        // const files = {
-        //   'tsconfig.json': {
-        //     code: `{
-        //       "compilerOptions": {
-        //         "baseUrl": "./",
-        //         "paths": {
-        //           "#src/*": ["src/*"],
-        //           i don't understand duplicating this aplias
-        //           '#src-test/*': ['src/*'],
-        //           "#rules/*": ["src/rules/*"]
-        //         }
-        //       }
-        //     }`
-        //   },
-        // }
-
         mockExistsSync.mockReturnValue(true);
         mockLoadAliasConfig.mockReturnValue([
             {
@@ -90,13 +73,11 @@ function runTests(platform: "win32" | "posix") {
                 code: `export * from '#rules/potato';`,
                 filename: "src/test.ts",
             },
-
             // does not apply for partial path match
             {
                 code: `export * from '../src-app/rules/potato';`,
                 filename: "src/test.ts",
             },
-
             // does not affect source-less exports
             {
                 code: `export default TestFn = () => {}`,

--- a/tests/rules/import-alias.test.ts
+++ b/tests/rules/import-alias.test.ts
@@ -154,6 +154,36 @@ function runTests(platform: "win32" | "posix") {
                     },
                 ],
             },
+
+            {
+                code: `export * from "./app";`,
+                filename: "src/index.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "index.ts",
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            {
+                code: `export * from "./app";`,
+                filename: "src/index.js",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: /index.{2,3}$/,
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
         ],
         invalid: [
             // more specific alias
@@ -255,6 +285,23 @@ function runTests(platform: "win32" | "posix") {
                     },
                 ],
                 output: `export * from "#src/potato";`,
+            },
+
+            {
+                code: `export * from "./app";`,
+                errors: 1,
+                filename: "src/index.js",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "index.ts",
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+                output: `export * from "#src/app";`,
             },
         ],
     });

--- a/tests/rules/import-alias.test.ts
+++ b/tests/rules/import-alias.test.ts
@@ -91,7 +91,7 @@ function runTests(platform: "win32" | "posix") {
                 filename: "src/test.ts",
             },
 
-            // relative path overridden for root, exporting a sibling module
+            // relative path overridden for root and exports from sibling module
             {
                 code: `export * from "./rules/potato";`,
                 filename: "src/test.ts",
@@ -107,9 +107,9 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // relative path overridden for a specified directory, exporting a sibling module
+            // relative path overridden for a specified directory and exports from sibling module
             {
-                code: `export * from "./rules/foo";`,
+                code: `export * from "./rules/potato";`,
                 filename: "src/test.ts",
                 options: [
                     {
@@ -123,7 +123,39 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // relative path overridde for a glob pattern, exporting a sibling module
+            // relative path overridden for root and exports from parent module
+            {
+                code: `export * from "../rules/potato";`,
+                filename: "src/test.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                path: ".",
+                                depth: 1,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            // relative path overridden for a specified directory and exports from parent module
+            {
+                code: `export * from "../rules/potato";`,
+                filename: "src/test.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                path: "src",
+                                depth: 1,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            // pattern override for a glob pattern, exporting a sibling module
             {
                 code: `export * from "./rules/bar";`,
                 filename: "src/index.ts",
@@ -131,7 +163,7 @@ function runTests(platform: "win32" | "posix") {
                     {
                         relativeImportOverrides: [
                             {
-                                pattern: "index\\.(ts|js)",
+                                pattern: "index\\.(ts|js)$",
                                 depth: 0,
                             },
                         ],
@@ -139,7 +171,23 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // mixing relative path overridde with path and pattern
+            // pattern matches as RegExp for exporting sibling module
+            {
+                code: `export * from "./rules/bar";`,
+                filename: "src/index.ts/foo.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "index.ts",
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            // mixing relative path override with path and pattern
             {
                 code: `export * from "./rules/foobar";`,
                 filename: "src/test.ts",
@@ -159,40 +207,40 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // depth priority when multiple overrides match
+            // depth priority by path when multiple overrides match
             {
                 code: `export * from "../rules/potato";`,
-                filename: "src/index.ts",
+                filename: "src/foo/index.ts",
                 options: [
                     {
                         relativeImportOverrides: [
                             {
-                                path: "src",
-                                depth: 1,
-                            },
-                            {
                                 pattern: "index\\.(ts|js)",
                                 depth: 0,
+                            },
+                            {
+                                path: "src",
+                                depth: 1,
                             },
                         ],
                     },
                 ],
             },
 
-            // depth priority when multiple overrides match
+            // depth priority by pattern when multiple overrides match
             {
                 code: `export * from "../rules/potato";`,
-                filename: "src/index.ts",
+                filename: "src/foo/index.ts",
                 options: [
                     {
                         relativeImportOverrides: [
                             {
-                                pattern: "index\\.(ts|js)",
-                                depth: 1,
-                            },
-                            {
                                 path: "src",
                                 depth: 0,
+                            },
+                            {
+                                pattern: "index\\.(ts|js)",
+                                depth: 1,
                             },
                         ],
                     },
@@ -229,7 +277,7 @@ function runTests(platform: "win32" | "posix") {
                 output: "export * from '#rules/potato';",
             },
 
-            // (root) relative export from parent, allowing only a depth of 0. Here the depth is 1
+            // (root) relative export from parent when only depth of 0 (sibling) is allowed
             {
                 code: `export * from "../potato";`,
                 errors: 1,
@@ -332,7 +380,6 @@ function runTests(platform: "win32" | "posix") {
                 code: `export { Potato } from '#rules/potato';`,
                 filename: "src/test.ts",
             },
-
             // does not apply for partial path match
             {
                 code: `export { Potato } from '../src-app/rules/potato';`,
@@ -354,7 +401,8 @@ function runTests(platform: "win32" | "posix") {
                 code: `const TestFn = () => {}; export { TestFn };`,
                 filename: "src/test.ts",
             },
-            // relative path overridde for root, exporting a sibling module
+
+            // relative path overridden for root and exports from sibling module
             {
                 code: `export { Potato } from "./rules/potato";`,
                 filename: "src/test.ts",
@@ -369,30 +417,16 @@ function runTests(platform: "win32" | "posix") {
                     },
                 ],
             },
-            // relative path overridde for a specified directory, exporting a sibling module
+
+            // relative path overridden for a specified directory and exports from sibling module
             {
-                code: `export { Potato } from "./rules/foo";`,
+                code: `export { Potato } from "./rules/potato";`,
                 filename: "src/test.ts",
                 options: [
                     {
                         relativeImportOverrides: [
                             {
                                 path: "src",
-                                depth: 0,
-                            },
-                        ],
-                    },
-                ],
-            },
-            // relative path overridde for a glob pattern, exporting a sibling module
-            {
-                code: `export { Potato } from "./rules/bar";`,
-                filename: "src/index.ts",
-                options: [
-                    {
-                        relativeImportOverrides: [
-                            {
-                                pattern: "index\\.(ts|js)",
                                 depth: 0,
                             },
                         ],
@@ -432,7 +466,39 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // mixing relative path overridde with path and pattern
+            // pattern override for a glob pattern, exporting a sibling module
+            {
+                code: `export { Potato } from "./rules/bar";`,
+                filename: "src/index.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "index\\.(ts|js)$",
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            // pattern matches as RegExp for exporting sibling module
+            {
+                code: `export { Potato } from "./rules/bar";`,
+                filename: "src/index.ts/foo.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "index.ts",
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            // mixing relative path override with path and pattern
             {
                 code: `export { Potato } from "./rules/foobar";`,
                 filename: "src/test.ts",
@@ -452,40 +518,40 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // depth priority when multiple overrides match
+            // depth priority by path when multiple overrides match
             {
                 code: `export { Potato } from "../rules/potato";`,
-                filename: "src/index.ts",
+                filename: "src/foo/index.ts",
                 options: [
                     {
                         relativeImportOverrides: [
                             {
-                                path: "src",
-                                depth: 1,
-                            },
-                            {
                                 pattern: "index\\.(ts|js)",
                                 depth: 0,
+                            },
+                            {
+                                path: "src",
+                                depth: 1,
                             },
                         ],
                     },
                 ],
             },
 
-            // depth priority when multiple overrides match
+            // depth priority by pattern when multiple overrides match
             {
                 code: `export { Potato } from "../rules/potato";`,
-                filename: "src/index.ts",
+                filename: "src/foo/index.ts",
                 options: [
                     {
                         relativeImportOverrides: [
                             {
-                                pattern: "index\\.(ts|js)",
-                                depth: 1,
-                            },
-                            {
                                 path: "src",
                                 depth: 0,
+                            },
+                            {
+                                pattern: "index\\.(ts|js)",
+                                depth: 1,
                             },
                         ],
                     },
@@ -521,7 +587,8 @@ function runTests(platform: "win32" | "posix") {
                 filename: "src/test.ts",
                 output: "export { Potato } from '#rules/potato';",
             },
-            // (root) relative export from parent, allowing only a depth of 0. Here the depth is 1
+
+            // (root) relative export from parent when only depth of 0 (sibling) is allowed
             {
                 code: `export { Potato } from "../potato";`,
                 errors: 1,
@@ -538,6 +605,7 @@ function runTests(platform: "win32" | "posix") {
                 ],
                 output: `export { Potato } from "#src/potato";`,
             },
+
             // (specified) relative export from parent when only depth of 0 (sibling) is allowed
             {
                 code: `export { Potato } from "../potato";`,
@@ -555,6 +623,7 @@ function runTests(platform: "win32" | "posix") {
                 ],
                 output: `export { Potato } from "#src/potato";`,
             },
+
             // relative path used in file that does not fall within override
             {
                 code: `export { Potato } from "./potato";`,
@@ -572,6 +641,7 @@ function runTests(platform: "win32" | "posix") {
                 ],
                 output: `export { Potato } from "#src/potato";`,
             },
+
             // relative path used to too large of a depth
             {
                 code: `export { Potato } from "../../potato";`,
@@ -697,7 +767,39 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // mixing relative path overridde with path and pattern
+            // pattern override for a glob pattern, exporting a sibling module
+            {
+                code: `import { Potato } from "./rules/foobar"`,
+                filename: "src/index.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "index\\.(ts|js)$",
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            // pattern matches as RegExp for exporting sibling module
+            {
+                code: `import { Potato } from "./rules/bar";`,
+                filename: "src/index.ts/foo.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "index.ts",
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            // mixing relative path override with path and pattern
             {
                 code: `import { Potato } from "./rules/foobar";`,
                 filename: "src/test.ts",
@@ -717,40 +819,40 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // depth priority when multiple overrides match
+            // depth priority by path when multiple overrides match
             {
                 code: `import { Potato } from "../rules/potato";`,
-                filename: "src/index.ts",
+                filename: "src/foo/index.ts",
                 options: [
                     {
                         relativeImportOverrides: [
                             {
-                                path: "src",
-                                depth: 1,
-                            },
-                            {
                                 pattern: "index\\.(ts|js)",
                                 depth: 0,
+                            },
+                            {
+                                path: "src",
+                                depth: 1,
                             },
                         ],
                     },
                 ],
             },
 
-            // depth priority when multiple overrides match
+            // depth priority by pattern when multiple overrides match
             {
                 code: `import { Potato } from "../rules/potato";`,
-                filename: "src/index.ts",
+                filename: "src/foo/index.ts",
                 options: [
                     {
                         relativeImportOverrides: [
                             {
-                                pattern: "index\\.(ts|js)",
-                                depth: 1,
-                            },
-                            {
                                 path: "src",
                                 depth: 0,
+                            },
+                            {
+                                pattern: "index\\.(ts|js)",
+                                depth: 1,
                             },
                         ],
                     },
@@ -967,7 +1069,39 @@ function runTests(platform: "win32" | "posix") {
                     ],
                 },
 
-                // mixing relative path overridde with path and pattern
+                // pattern override for a glob pattern, exporting a sibling module
+                {
+                    code: `require("./rules/foobar")`,
+                    filename: "src/index.ts",
+                    options: [
+                        {
+                            relativeImportOverrides: [
+                                {
+                                    pattern: "index\\.(ts|js)$",
+                                    depth: 0,
+                                },
+                            ],
+                        },
+                    ],
+                },
+
+                // pattern matches as RegExp for exporting sibling module
+                {
+                    code: `require("./rules/foobar")`,
+                    filename: "src/index.ts/foo.ts",
+                    options: [
+                        {
+                            relativeImportOverrides: [
+                                {
+                                    pattern: "index.ts",
+                                    depth: 0,
+                                },
+                            ],
+                        },
+                    ],
+                },
+
+                // mixing relative path override with path and pattern
                 {
                     code: `require("./rules/foobar")`,
                     filename: "src/test.ts",
@@ -987,40 +1121,40 @@ function runTests(platform: "win32" | "posix") {
                     ],
                 },
 
-                // depth priority when multiple overrides match
+                // depth priority by path when multiple overrides match
                 {
                     code: `require("../rules/potato")`,
-                    filename: "src/index.ts",
+                    filename: "src/foo/index.ts",
                     options: [
                         {
                             relativeImportOverrides: [
                                 {
-                                    path: "src",
-                                    depth: 1,
-                                },
-                                {
                                     pattern: "index\\.(ts|js)",
                                     depth: 0,
+                                },
+                                {
+                                    path: "src",
+                                    depth: 1,
                                 },
                             ],
                         },
                     ],
                 },
 
-                // depth priority when multiple overrides match
+                // depth priority by pattern when multiple overrides match
                 {
                     code: `require("../rules/potato")`,
-                    filename: "src/index.ts",
+                    filename: "src/foo/index.ts",
                     options: [
                         {
                             relativeImportOverrides: [
                                 {
-                                    pattern: "index\\.(ts|js)",
-                                    depth: 1,
-                                },
-                                {
                                     path: "src",
                                     depth: 0,
+                                },
+                                {
+                                    pattern: "index\\.(ts|js)",
+                                    depth: 1,
                                 },
                             ],
                         },
@@ -1230,7 +1364,40 @@ function runTests(platform: "win32" | "posix") {
                         },
                     ],
                 },
-                // mixing relative path overridde with path and pattern
+
+                // pattern override for a glob pattern, exporting a sibling module
+                {
+                    code: `jest.mock("./rules/foobar")`,
+                    filename: "src/test.ts",
+                    options: [
+                        {
+                            relativeImportOverrides: [
+                                {
+                                    pattern: "test\\.(ts|js)$",
+                                    depth: 0,
+                                },
+                            ],
+                        },
+                    ],
+                },
+
+                // pattern matches as RegExp for exporting sibling module
+                {
+                    code: `jest.mock("./rules/foobar")`,
+                    filename: "src/index.ts/foo.ts",
+                    options: [
+                        {
+                            relativeImportOverrides: [
+                                {
+                                    pattern: "index.ts",
+                                    depth: 0,
+                                },
+                            ],
+                        },
+                    ],
+                },
+
+                // mixing relative path override with path and pattern
                 {
                     code: `jest.mock("./rules/foobar")`,
                     filename: "src/test.ts",
@@ -1249,39 +1416,40 @@ function runTests(platform: "win32" | "posix") {
                         },
                     ],
                 },
-                // depth priority when multiple overrides match
+                // depth priority by path when multiple overrides match
                 {
                     code: `jest.mock("../rules/potato")`,
-                    filename: "src/index.ts",
+                    filename: "src/foo/index.ts",
                     options: [
                         {
                             relativeImportOverrides: [
                                 {
-                                    path: "src",
-                                    depth: 1,
-                                },
-                                {
                                     pattern: "index\\.(ts|js)",
                                     depth: 0,
+                                },
+                                {
+                                    path: "src",
+                                    depth: 1,
                                 },
                             ],
                         },
                     ],
                 },
-                // depth priority when multiple overrides match
+
+                // depth priority by pattern when multiple overrides match
                 {
                     code: `jest.mock("../rules/potato")`,
-                    filename: "src/index.ts",
+                    filename: "src/foo/index.ts",
                     options: [
                         {
                             relativeImportOverrides: [
                                 {
-                                    pattern: "index\\.(ts|js)",
-                                    depth: 1,
-                                },
-                                {
                                     path: "src",
                                     depth: 0,
+                                },
+                                {
+                                    pattern: "index\\.(ts|js)",
+                                    depth: 1,
                                 },
                             ],
                         },
@@ -1508,7 +1676,7 @@ function runTests(platform: "win32" | "posix") {
                         ],
                     },
 
-                    // relative path overridde for a glob pattern, exporting a sibling module
+                    // pattern override for a glob pattern, exporting a sibling module
                     {
                         code: `potato("./rules/foobar")`,
                         filename: "src/index.ts",
@@ -1517,7 +1685,7 @@ function runTests(platform: "win32" | "posix") {
                                 aliasImportFunctions: ["potato"],
                                 relativeImportOverrides: [
                                     {
-                                        pattern: "index\\.(ts|js)",
+                                        pattern: "index\\.(ts|js)$",
                                         depth: 0,
                                     },
                                 ],
@@ -1525,7 +1693,23 @@ function runTests(platform: "win32" | "posix") {
                         ],
                     },
 
-                    // mixing relative path overridde with path and pattern
+                    // pattern matches as RegExp for exporting sibling module
+                    {
+                        code: `potato("./rules/foobar")`,
+                        filename: "src/index.ts/foo.ts",
+                        options: [
+                            {
+                                relativeImportOverrides: [
+                                    {
+                                        pattern: "index.ts",
+                                        depth: 0,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+
+                    // mixing relative path override with path and pattern
                     {
                         code: `potato("./rules/foobar")`,
                         filename: "src/test.ts",
@@ -1546,21 +1730,41 @@ function runTests(platform: "win32" | "posix") {
                         ],
                     },
 
-                    // depth priority when multiple overrides match
+                    // depth priority by path when multiple overrides match
                     {
                         code: `potato("../rules/potato")`,
-                        filename: "src/index.ts",
+                        filename: "src/foo/index.ts",
                         options: [
                             {
                                 aliasImportFunctions: ["potato"],
                                 relativeImportOverrides: [
                                     {
+                                        pattern: "index\\.(ts|js)",
+                                        depth: 0,
+                                    },
+                                    {
                                         path: "src",
                                         depth: 1,
                                     },
+                                ],
+                            },
+                        ],
+                    },
+
+                    // depth priority by pattern when multiple overrides match
+                    {
+                        code: `jest.mock("../rules/potato")`,
+                        filename: "src/foo/index.ts",
+                        options: [
+                            {
+                                relativeImportOverrides: [
+                                    {
+                                        path: "src",
+                                        depth: 0,
+                                    },
                                     {
                                         pattern: "index\\.(ts|js)",
-                                        depth: 0,
+                                        depth: 1,
                                     },
                                 ],
                             },

--- a/tests/rules/import-alias.test.ts
+++ b/tests/rules/import-alias.test.ts
@@ -39,6 +39,7 @@ function runTests(platform: "win32" | "posix") {
             sep: path[platform].sep,
             join: path[platform].join,
         });
+
         mockExistsSync.mockReturnValue(true);
         mockLoadAliasConfig.mockReturnValue([
             {
@@ -78,13 +79,19 @@ function runTests(platform: "win32" | "posix") {
                 code: `export * from '../src-app/rules/potato';`,
                 filename: "src/test.ts",
             },
+            // selects correct alias despite #src being a partial match
+            // and comes first/is shorter as an alias
+            {
+                code: `export * from '../src-test/rules/potato';`,
+                filename: "src/test.ts",
+            },
             // does not affect source-less exports
             {
                 code: `export default TestFn = () => {}`,
                 filename: "src/test.ts",
             },
 
-            // relative path overridde for root, exporting a sibling module
+            // relative path overridden for root, exporting a sibling module
             {
                 code: `export * from "./rules/potato";`,
                 filename: "src/test.ts",
@@ -100,7 +107,7 @@ function runTests(platform: "win32" | "posix") {
                 ],
             },
 
-            // relative path overridde for a specified directory, exporting a sibling module
+            // relative path overridden for a specified directory, exporting a sibling module
             {
                 code: `export * from "./rules/foo";`,
                 filename: "src/test.ts",
@@ -340,6 +347,11 @@ function runTests(platform: "win32" | "posix") {
             // does not affect source-less named exports
             {
                 code: `export const TestFn = () => {}`,
+                filename: "src/test.ts",
+            },
+            // does not affect source-less named exports
+            {
+                code: `const TestFn = () => {}; export { TestFn };`,
                 filename: "src/test.ts",
             },
             // relative path overridde for root, exporting a sibling module

--- a/tests/rules/import-alias.test.ts
+++ b/tests/rules/import-alias.test.ts
@@ -162,7 +162,7 @@ function runTests(platform: "win32" | "posix") {
                     {
                         relativeImportOverrides: [
                             {
-                                pattern: "index.ts",
+                                pattern: "index.ts$",
                                 depth: 0,
                             },
                         ],
@@ -177,7 +177,11 @@ function runTests(platform: "win32" | "posix") {
                     {
                         relativeImportOverrides: [
                             {
-                                pattern: /index.{2,3}$/,
+                                pattern: "index.{2,3}$",
+                                depth: 0,
+                            },
+                            {
+                                path: "src",
                                 depth: 0,
                             },
                         ],
@@ -287,15 +291,20 @@ function runTests(platform: "win32" | "posix") {
                 output: `export * from "#src/potato";`,
             },
 
+            // invalid because path take priority over pattern
             {
-                code: `export * from "./app";`,
+                code: `export * from "../app";`,
+                filename: "src/rules/index.ts",
                 errors: 1,
-                filename: "src/index.js",
                 options: [
                     {
                         relativeImportOverrides: [
                             {
-                                pattern: "index.ts",
+                                pattern: "index.{2,3}$",
+                                depth: 0,
+                            },
+                            {
+                                path: "src",
                                 depth: 0,
                             },
                         ],

--- a/tests/rules/import-alias.test.ts
+++ b/tests/rules/import-alias.test.ts
@@ -423,6 +423,26 @@ function runTests(platform: "win32" | "posix") {
                                 pattern: /index.{2,3}$/,
                                 depth: 0,
                             },
+                            {
+                                pattern: /foo.{2,3}$/,
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+
+            // valid because the pattern is tested againt the whole path
+            {
+                code: `export { Potato } from "../../potato";`,
+                filename: "src/rules/foo/bar.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "rules",
+                                depth: 2,
+                            },
                         ],
                     },
                 ],
@@ -535,6 +555,24 @@ function runTests(platform: "win32" | "posix") {
                 errors: 1,
                 filename: "src/index.js",
                 output: `export { Potato } from "#src/app";`,
+            },
+
+            // relative path used to too large of a depth
+            {
+                code: `export { Potato } from "../../potato";`,
+                errors: 1,
+                filename: "src/rules/foo/bar.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: "rules",
+                                depth: 1,
+                            },
+                        ],
+                    },
+                ],
+                output: `export { Potato } from "#src/potato";`,
             },
         ],
     });

--- a/tests/rules/import-alias.test.ts
+++ b/tests/rules/import-alias.test.ts
@@ -402,6 +402,22 @@ function runTests(platform: "win32" | "posix") {
                     },
                 ],
             },
+
+            // relative path overridden for index file
+            {
+                code: `export { Potato } from "./app";`,
+                filename: "src/index.ts",
+                options: [
+                    {
+                        relativeImportOverrides: [
+                            {
+                                pattern: /index.{2,3}$/,
+                                depth: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
         ],
         invalid: [
             // more specific alias
@@ -503,6 +519,13 @@ function runTests(platform: "win32" | "posix") {
                     },
                 ],
                 output: `export { Potato } from "#src/potato";`,
+            },
+
+            {
+                code: `export { Potato } from "./app";`,
+                errors: 1,
+                filename: "src/index.js",
+                output: `export { Potato } from "#src/app";`,
             },
         ],
     });


### PR DESCRIPTION
#### SUMMARY

This PR allows to override the alias import rule in order to handle filenames. This update allow to use pattern string that are use as Regex and depth in the same way as before

#### CHANGES

- Added new implementation handling path and pattern arrays
- Added few tests